### PR TITLE
Fix debian family ini file location

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,11 @@ default['tideways']['yum_url'] = 'https://s3-eu-west-1.amazonaws.com/qafoo-profi
 default['tideways']['apt_url'] = 'http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages'
 default['tideways']['gpgkey'] = 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg'
 
-default['tideways']['ini_file'] = '40-tideways.ini'
+default['tideways']['ini_file'] = if platform_family?('rhel', 'fedora')
+   '40-tideways.ini'
+else
+   'tideways.ini'
+end
 
 default['tideways']['php_service_name'] = 'php-fpm'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,10 +3,10 @@ default['tideways']['apt_url'] = 'http://s3-eu-west-1.amazonaws.com/qafoo-profil
 default['tideways']['gpgkey'] = 'https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg'
 
 default['tideways']['ini_file'] = if platform_family?('rhel', 'fedora')
-   '40-tideways.ini'
-else
-   'tideways.ini'
-end
+                                    '40-tideways.ini'
+                                  else
+                                    'tideways.ini'
+                                  end
 
 default['tideways']['php_service_name'] = 'php-fpm'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'tideways'
-version '0.4.1'
+version '0.4.2'
 maintainer 'Rupert Jones'
 maintainer_email 'rjones@inviqa.com'
 license 'Apache 2.0'


### PR DESCRIPTION
It's only the rhel-flavour rpms from the yum repository that create 40-tideways.ini The debian-flavour debs instead create tideways.ini